### PR TITLE
Update Node.js version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: ⚙️ Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: 🧽 Run ESLint
         run: |


### PR DESCRIPTION
## Summary
- use Node.js 18 in the CI workflow

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c5b1dff5c832db18791c120245a64