### PR TITLE
Update ESLint step to use api folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: 🧽 Run ESLint
         run: |
-          npm install
-          npx eslint . || true
+          npm install --prefix api
+          npx eslint api || true


### PR DESCRIPTION
## Summary
- install Node dependencies in the `api` folder during CI
- run ESLint on the `api` directory

## Testing
- `black . --check`
- `npx eslint api`


------
https://chatgpt.com/codex/tasks/task_e_684c6537f920832d895fa4ee127ff6e0