### PR TITLE
Fix GitHub CI npm step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: 🧽 Run ESLint
         run: |
-          npm install
-          npx eslint . || true
+          npm install --prefix api
+          npx --prefix api eslint . || true


### PR DESCRIPTION
## Summary
- fix GitHub workflow to install Node dependencies from the `api` folder so ESLint can run

## Testing
- `black . --check`
- `npm install --prefix api`
- `npx --prefix api eslint .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c648e69fc832d963b187c89979439