### PR TITLE
Handle missing env vars in daily API

### DIFF
--- a/api/daily.js
+++ b/api/daily.js
@@ -1,21 +1,34 @@
 export default async function handler(req, res) {
-  const prompt = "🌇 Cinematic sunset prompt of futuristic Kuala Lumpur skyline, ultra vibrant, soft neon, ambient lighting.";
+  const promptText =
+    "\ud83c\udf07 Cinematic sunset prompt of futuristic Kuala Lumpur skyline, ultra vibrant, soft neon, ambient lighting.";
   const token = process.env.DROP_BOT_TOKEN;
   const chatId = process.env.DROP_CHANNEL_ID;
 
-  const telegramURL = `https://api.telegram.org/bot${token}/sendMessage`;
+  if (!token || !chatId) {
+    return res.status(500).json({ error: "Missing bot configuration" });
+  }
+
+  const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
 
   const payload = {
     chat_id: chatId,
-    text: `🖼️ *Daily Prompt Drop*\n\n${prompt}`,
-    parse_mode: "Markdown"
+    text: `\ud83d\uddfe\ufe0f *Daily Prompt Drop*\n\n${promptText}`,
+    parse_mode: "Markdown",
   };
 
-  await fetch(telegramURL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+  try {
+    const response = await fetch(telegramUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
 
-  res.status(200).send("✅ Drop sent");
+    if (!response.ok) {
+      throw new Error(`Telegram API error: ${response.statusText}`);
+    }
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+
+  return res.status(200).json({ message: "\u2705 Drop sent" });
 }


### PR DESCRIPTION
## Summary
- add Telegram error handling in `api/daily.js`

## Testing
- `black . --check`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_684c6ffc32bc832d8f8afaac86b073a8